### PR TITLE
Include all labels

### DIFF
--- a/allcontainers.js
+++ b/allcontainers.js
@@ -163,7 +163,7 @@ function allContainers (opts) {
       id: container.Id,
       image: container.Image,
       name: container.Names[0].replace(/^\//, ''),
-      label: container.label
+      labels: container.Labels
     }
   }
 }


### PR DESCRIPTION
As far as I can understand, `container.label` is non-functional, as there is no such property on `container`. What there is, however, is a map of labels, under the `Labels` property. So include that instead.